### PR TITLE
added Hapi Universal Redux to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
     * [Redux + Datascript](https://github.com/jlongster/redux-experiments)
     * [Ripster](https://github.com/vslinko/ripster)
     * [redux-remote](https://github.com/lapanoid/redux-remote)
+    * [Hapi Universal Redux](https://github.com/Luandro/hapi-universal-redux)
 
 * Similar libraries
     * [flux-ts](https://github.com/BobBuehler/flux-ts)


### PR DESCRIPTION
Just added a very succinct example based on [React Isomorphic Starterkit](https://github.com/RickWong/react-isomorphic-starterkit). It's a very good starting point for anyone who wants to use or simply understand Redux.