### PR TITLE
Update Redux repo and documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 > List of repositories which use Redux
 
-## [Redux](https://github.com/gaearon/redux)
-## [Documentation of Redux](http://gaearon.github.io/redux)
+## [Redux](https://github.com/rackt/redux)
+## [Documentation of Redux](http://rackt.github.io/redux)
 
 > Predictable state container for JavaScript apps
 


### PR DESCRIPTION
This PR updates the Redux repo and documentation URLs after the August 14th move of Redux to the [rackt](https://github.com/rackt) group.