### PR TITLE
Add combine/react-redux-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 ---
 
 ### Boilerplate
+* [**react-redux-starter** - Universal React + Redux with Cordova support and an opinionated directory structure](https://github.com/combine/react-redux-starter)
 * [**react-slingshot** - React Redux Starter Kit with hot reloading, tests and example app](https://github.com/coryhouse/react-slingshot)
 * [**react-redux-boilerplate** - React Redux Boilerplate](https://github.com/knowbody/react-redux-boilerplate)
 * [**react-boilerplate** - React + Typescript + Sass boilerplate](https://github.com/Keats/react-boilerplate)
@@ -379,7 +380,7 @@ ___
     * [https://github.com/ReSwift/reduxSwift](https://github.com/ReSwift/reduxSwift)
     * [https://github.com/Swift-Flow/Swift-Flow](https://github.com/Swift-Flow/Swift-Flow)
     * [https://github.com/ReSwift/ReSwift](https://github.com/ReSwift/ReSwift) and [docs](http://reswift.github.io/ReSwift/master)
-    
+
 * Purescript
     * [https://github.com/brakmic/purescript-redux](https://github.com/brakmic/purescript-redux)
     * [https://github.com/faber/purescript-purdux](https://github.com/faber/purescript-purdux)


### PR DESCRIPTION
While learning React + Redux, I referenced [RRUHE](https://github.com/erikras/react-redux-universal-hot-example) a lot, but found it to be a bit complex and I didn't like the directory structure. So I decided to rip out what I did and put it up with some examples, an opinionated directory structure, and these features:

- Universal rendering with react and react-router
- Hot reloading with WebpackDevServer and react-transform-hmr
- The new react-router-redux for react-router -> redux bindings
- Babel 6 for ES2015
- Cordova support with hot reloading, a build tool, and a distribution tool that uploads your binaries to Fabric/Crashlytics
- Webpack configurations for production, development, and cordova