### PR TITLE
Add ARc to boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 * [**vortigern** - A universal boilerplate for building web applications w/ TypeScript, React, Redux and more.](https://github.com/barbar/vortigern)
 * [**angular2-redux-contact-list** - Simple contact list built with Angular 2, Immutable.js and Redux](https://github.com/hdjirdeh/angular2-redux-contact-list)
 * [**react-redux-seed** - 使用 React 与 Redux 实现 Universal 渲染的种子工程](https://github.com/lewis617/react-redux-seed)
+* [**ARc** - A progressive React starter kit based on Atomic Design with redux, redux-saga and redux-form](https://arc.js.org)
 
 ---
 


### PR DESCRIPTION
Hi, guys. [ARc](https://github.com/diegohaz/arc) is a React starter kit based on Atomic Design by Brad Frost and has appeared in 
- Rank 7 on [Mybridge's React.JS Top 10 Articles in October](https://medium.mybridge.co/react-js-top-ten-in-october-48998cdde5a3#.780m20e10)
- Rank 5 on [Top 50 Lightweight JavaScript Plugins & Libraries from 2016](https://speckyboy.com/top-50-javascript-2016/)

I think it would be a nice addition to the list.

Thanks.