### PR TITLE
Update Japanese version's site URL of Redux documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 ## [Documentation of Redux(Spanish version)](https://sergiodxa.gitbooks.io/redux-en-espanol/content/) (Work in progress)
 ## [Documentation of Redux(Korean version)](http://dobbit.github.io/redux/)
 ## [Documentation of Redux(Sinhala|සිංහල version)](https://sandaruny.github.io/redux-sin/) (Work in progress)
-## [Documentation of Redux(Japanese|日本語 version)](https://0-to-1.github.io/redux/) (Work in progress)
+## [Documentation of Redux(Japanese|日本語 version)](https://miya-start.github.io/redux/) (Work in progress)
 
 > Predictable state container for JavaScript apps
 


### PR DESCRIPTION
The GitHub Pages URL is changed because I renamed my GitHub account.

It is #296 that my former pull request to add Japanese version of Redux documentation.