### PR TITLE
Add redux-dom-mutation-observer middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@
     https://github.com/cyclejs-community/redux-cycles)
     * [**axios-promise-redux-middleware** - This is a tiny redux middleware which allows you to make http requests(using axios) by dispatching actions](https://www.npmjs.com/package/axios-promise-redux-middleware)
     * [**redux-callbag** - Redux middleware for action side effects with callbag + Extremely lightweight and highly scalable](https://github.com/janryWang/redux-callbag)
+    * [**redux-dom-mutation-observer** - A Redux middleware to handle DOM mutations via MutationObserver Web API.](https://github.com/karatsuba/redux-dom-mutation-observer)
     * [**@reactive-crystal/redux-websocket** - Redux Websocket middleware, reducer and protocol router. ](https://www.npmjs.com/package/@reactive-crystal/redux-websocket)
 
 


### PR DESCRIPTION
**redux-dom-mutation-observer** - Redux middleware to handle DOM mutations via [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) Web API.